### PR TITLE
Alias

### DIFF
--- a/lib/dru/commands/attach.rb
+++ b/lib/dru/commands/attach.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../container_command'
+require_relative '../command'
 
 module Dru
   module Commands

--- a/lib/dru/config.rb
+++ b/lib/dru/config.rb
@@ -8,10 +8,11 @@ module Dru
     extend Forwardable
     include Singleton
 
-    def_delegators :configs, :docker_projects_folder
+    def_delegators :configs, :docker_projects_folder, :alias
 
     DEFAULT = {
-      'docker_projects_folder' => "~/.dru"
+      'docker_projects_folder' => "~/.dru",
+      'alias' => {}
     }.freeze
 
     attr_reader :config_file_path

--- a/lib/dru/config.rb
+++ b/lib/dru/config.rb
@@ -11,7 +11,7 @@ module Dru
     def_delegators :configs, :docker_projects_folder
 
     DEFAULT = {
-      'docker_projects_folder' => "~/.dru" 
+      'docker_projects_folder' => "~/.dru"
     }.freeze
 
     attr_reader :config_file_path
@@ -29,6 +29,7 @@ module Dru
 
     def user_configs
       return {} unless config_file_path && File.file?(config_file_path)
+
       YAML.load_file(config_file_path) || {}
     end
   end

--- a/spec/unit/argv_spec.rb
+++ b/spec/unit/argv_spec.rb
@@ -19,10 +19,24 @@ RSpec.describe Dru::Argv do
 
     context 'when argv does not contain a docker compose command' do
       context 'and does not contain a dru command' do
-        let(:argv) { ['-e', 'test', 'unknown-command'] }
+        context 'and does not contain an alias command' do
+          let(:argv) { ['-e', 'test', 'unknown-command'] }
 
-        it 'does not change argv attribute' do
-          is_expected.to eq(argv)
+          it 'does not change argv attribute' do
+            is_expected.to eq(argv)
+          end
+        end
+
+        context 'and contains an alias command' do
+          let(:argv) { ['-e', 'test', 'alias-command'] }
+          let(:dru_alias) { OpenStruct.new({ 'alias-command' => 'run alias command' }) }
+          let(:expected_argv) { ['-e', 'test', '--', 'run', 'alias', 'command'] }
+
+          before do
+            allow(Dru).to receive(:config).and_return(double(:config, alias: dru_alias))
+          end
+
+          it { is_expected.to eq(expected_argv) }
         end
       end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -4,7 +4,7 @@ require 'tempfile'
 RSpec.describe Dru::Config do
   it { expect { described_class.new }.to raise_error(NoMethodError) }
 
-  let(:instance) { described_class.instance } 
+  let(:instance) { described_class.instance }
   let(:config_file) { Tempfile.new('.druconfig') }
   let(:config_file_path) { config_file.path }
 
@@ -42,8 +42,8 @@ RSpec.describe Dru::Config do
         it { is_expected.to eq described_class::DEFAULT['docker_projects_folder'] }
       end
 
-      context "when .driconfig have the key" do
-        let(:docker_projects_folder) { '/tmp/.nebulab_projects' } 
+      context "when .druconfig have the key" do
+        let(:docker_projects_folder) { '/tmp/.nebulab_projects' }
 
         before do
           config_file.write("docker_projects_folder: #{docker_projects_folder}")
@@ -54,5 +54,34 @@ RSpec.describe Dru::Config do
       end
     end
   end
-end
 
+  describe '#alias' do
+    subject { instance.alias }
+
+    before { instance.config_file_path = config_file_path }
+
+    context "when .druconfig doesn't exist" do
+      let(:config_file_path) { 'wrong_path' }
+
+      it { expect(subject.to_h).to eq described_class::DEFAULT['alias'] }
+    end
+
+    context "when .druconfig exists" do
+      context "when .druconfig doesn't have the key" do
+        it { expect(subject.to_h).to eq described_class::DEFAULT['alias'] }
+      end
+
+      context "when .druconfig have the key" do
+        let(:alias_name) { 'alias_name' }
+        let(:alias_command) { 'run a command' }
+
+        before do
+          config_file.write("alias:\n  #{alias_name}: #{alias_command}")
+          config_file.rewind
+        end
+
+        it { expect(subject[alias_name]).to eq alias_command }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #10 

Now it is possible to add custom aliases in the .druconfig file using the following syntax:
```yaml
alias:
  alias-name: alias command
```

Is it also possible to create an alias that uses an alias, in a recursive way:

```yaml
alias:
  alias-name: alias command
  second-alias: run alias-name
```