### PR TITLE
Refactor Dru::Command#run_docker_compose_command

### DIFF
--- a/lib/dru/commands/docker_compose.rb
+++ b/lib/dru/commands/docker_compose.rb
@@ -5,15 +5,13 @@ require_relative '../command'
 module Dru
   module Commands
     class DockerCompose < Dru::Command
-      attr_reader :command
-
       def initialize(options:, command:)
         @options = options
         @command = command
       end
 
       def execute(input: $stdin, output: $stdout)
-        run_docker_compose_command(*command, tty: true)
+        run_docker_compose_command(*@command, tty: true)
       end
     end
   end

--- a/lib/dru/commands/runner.rb
+++ b/lib/dru/commands/runner.rb
@@ -6,12 +6,12 @@ module Dru
   module Commands
     class Runner < Dru::ContainerCommand
       def execute(input: $stdin, output: $stdout)
-        run_docker_compose_command('run', '--rm', '--entrypoint', 'sh -c', container, command, tty: true)
+        run_docker_compose_command('run', '--rm', '--entrypoint', 'sh -c', container, commands, tty: true)
       end
 
       private
 
-      def command
+      def commands
         @command.join(' ')
       end
     end


### PR DESCRIPTION
closes #16

This allows us to use just `TTY::Command` instead to switch to `system` when we need to attach to `stdin`.